### PR TITLE
Webpack2 Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,8 @@
 const readJSON = require('read-package-json')
-const multipipe = require('multipipe')
-const from2 = require('from2-array')
 const resolve = require('resolve')
 const map = require('map-limit')
 const findup = require('findup')
 const path = require('path')
-const bl = require('bl')
 
 module.exports = loader
 
@@ -61,17 +58,10 @@ function loader (source) {
         if (err) return done(err)
 
         transforms.forEach(function (tr) {
-          tr.on('file', function (file) {
-            self.addDependency(file)
-          })
+          self.addDependency(tr)
         })
 
-        transforms = []
-          .concat(from2([source]))
-          .concat(transforms)
-
-        multipipe.apply(this, transforms)
-          .pipe(bl(done))
+        done(null, transforms.join(''))
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,8 @@
     "url": "https://github.com/hughsk"
   },
   "dependencies": {
-    "bl": "^1.0.0",
     "findup": "^0.1.5",
-    "from2-array": "0.0.4",
     "map-limit": "0.0.1",
-    "multipipe": "^0.3.0",
     "read-package-json": "^2.0.2",
     "resolve": "^1.1.6"
   },


### PR DESCRIPTION
Addresses #5 (error occurring with webpack2)

## Problem

I was having the same type of errors when trying to set up this loader with webpack2 (i.e. `tr.on is not a function`). I was just trying to hook up my shaders to run through `glslify`.

```
      {
        test: /\.(glsl|vert|v|frag|f)$/,
        loader: 'ify-loader'
      },
```

## Direct Solution

It seems that webpack 2 goes ahead and takes care of a lot of the loading/sequencing behind the scenes, so we get strings for the `transforms`/`tr` on line 64 instead of Buffers(?).

## Best Solution = ?

@hughsk Perhaps you can let me know if the fix I came up with is actually a good idea. I'm fairly new to webpack/browserify/glslify and I'm not sure what I might be breaking with this "fix". But perhaps this might help you identify the right solution faster.

This "fix" unblocks my development locally for now, but my usage is very simple with default options.