### PR TITLE
Replace read-package-json by standard nodejs require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const readJSON = require('read-package-json')
 const multipipe = require('multipipe')
 const from2 = require('from2-array')
 const resolve = require('resolve')
@@ -6,6 +5,17 @@ const map = require('map-limit')
 const findup = require('findup')
 const path = require('path')
 const bl = require('bl')
+
+function readJSON (jsonFile, cb) {
+  if (typeof cb !== 'function') return
+
+  try {
+    const jsonContent = require(jsonFile)
+    cb(null, jsonContent)
+  } catch (err) {
+    cb(err)
+  }
+}
 
 module.exports = loader
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "from2-array": "0.0.4",
     "map-limit": "0.0.1",
     "multipipe": "^0.3.0",
-    "read-package-json": "^2.0.2",
     "resolve": "^1.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/browserify/ify-loader/issues/18#issue-733331365

This will fix the naming error when package.json do not follow the `npm` rules